### PR TITLE
Specify a version of pandas for python@2

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -5,7 +5,7 @@ prctl
 #  Postgap dependencies
 pybedtools==0.7.4
 requests
-pandas
+pandas==0.24.1
 flask
 cherrypy
 h5py==2.8.0


### PR DESCRIPTION
From v0.25.0, pandas does not work with python@2, thus we need to use an older version.
More info at: https://pandas.pydata.org/#v0-25-0-final-july-18-2019
