### PR TITLE
Add CrossMap to Python package list

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -11,3 +11,4 @@ cherrypy
 h5py==2.8.0
 pysqlite
 scipy==0.18.1
+CrossMap==0.6.4


### PR DESCRIPTION
This PR adds CrossMap to Python's requirements for web.
Related PR: https://github.com/Ensembl/homebrew-cask/pull/37